### PR TITLE
x86_64 Support

### DIFF
--- a/module.modulemap
+++ b/module.modulemap
@@ -1,4 +1,4 @@
-module COpenBlas86 [system] {
+module COpenBlas [system] {
   header "/usr/include/x86_64-linux-gnu/cblas-openblas.h"
   header "/usr/include/lapacke.h"
 

--- a/module.modulemap
+++ b/module.modulemap
@@ -6,7 +6,7 @@ module COpenBlas [system] {
 
   export *
 }
-module COpenBlas86 [system] {
+module COpenBlas86_64 [system] {
   header "/usr/include/x86_64-linux-gnu/cblas-openblas.h"
   header "/usr/include/lapacke.h"
 

--- a/module.modulemap
+++ b/module.modulemap
@@ -7,7 +7,7 @@ module COpenBlas [system] {
 
   export *
 }
-module COpenBlas [system] {
+module COpenBlas86 [system] {
   header "/usr/include/x86_64-linux-gnu/cblas-openblas.h"
   header "/usr/include/lapacke.h"
 

--- a/module.modulemap
+++ b/module.modulemap
@@ -7,3 +7,12 @@ module COpenBlas [system] {
 
   export *
 }
+module COpenBlas [system] {
+  header "/usr/include/x86_64-linux-gnu/cblas-openblas.h"
+  header "/usr/include/lapacke.h"
+
+  link "openblas"
+  link "lapacke"
+
+  export *
+}

--- a/module.modulemap
+++ b/module.modulemap
@@ -1,4 +1,12 @@
 module COpenBlas [system] {
+  header "/usr/include/aarch64-linux-gnu/cblas-openblas.h"
+  header "/usr/include/lapacke.h"
+  link "openblas"
+  link "lapacke"
+
+  export *
+}
+module COpenBlas86 [system] {
   header "/usr/include/x86_64-linux-gnu/cblas-openblas.h"
   header "/usr/include/lapacke.h"
 

--- a/module.modulemap
+++ b/module.modulemap
@@ -1,12 +1,3 @@
-module COpenBlas [system] {
-  header "/usr/include/aarch64-linux-gnu/cblas-openblas.h"
-  header "/usr/include/lapacke.h"
-
-  link "openblas"
-  link "lapacke"
-
-  export *
-}
 module COpenBlas86 [system] {
   header "/usr/include/x86_64-linux-gnu/cblas-openblas.h"
   header "/usr/include/lapacke.h"


### PR DESCRIPTION
Add COpenBlas86_64 for x86_64 architecture support. Use
```
#if canImport(COpenBlas)
import COpenBlas
#else
import COpenBlas86_64
#endif
```
to import the correct framework on the correct architecture.